### PR TITLE
fix: add eslint rules auto end of line

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,12 @@
     ],
     "rules": {
         "@typescript-eslint/triple-slash-reference": "off",
-        "prettier/prettier": "error"
+        "prettier/prettier": [
+            "error",
+            {
+                "endOfLine": "auto"
+            }
+        ]
     },
     "settings": {
         "react": {


### PR DESCRIPTION
### 주요내용
eslint 설정 문제 수정 

### 이슈
윈도우에서 스토리북 실행시 프리티어 에러로 CRLF와 LF관련 문제가 터집니다.
```shell
Line 00:00:  Delete `␍`  prettier/prettier
```
다음과 같이 기본 CRLF를 사용한는 환경에서 사용이 어려워, 프리티어 룰을 다음과 같이 조금 변경하였습니다.

```json
  "rules": {
      "@typescript-eslint/triple-slash-reference": "off",
      "prettier/prettier": [
          "error",
          {
              "endOfLine": "auto"
          }
      ]
  },
```
개행문자 (\n or \r)을 LF나 CR 로 고정하지 않고 운영체제에 맞게 사용하도록 바꿔주는 옵션입니다.
해당 룰 추가하니 더이상 같은 문제가 발생하지 않았습니다. 

#### 참고
https://stack94.tistory.com/entry/Prettier-eslint-delete-CR-prettierprettier-%EC%97%90%EB%9F%AC