### PR TITLE
feat: update starting guide on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,24 @@ _Features:_
 
 ### 1. Install
 
-You can install package by the conmand below
+You can install package by the conmand below.
 
 ```bash
 npm install @juicy-plus/react-juicy-modal
 ```
 
-you can also use other package managers such as yarn, pnpm
+You can also use other package managers such as yarn, pnpm
 
 ### 2. Use ModalRoot at the root.
 
-Use the component `ModalRoot` where the modal will actually be rendered.(Mostly would be at the root of your app)
+`ModalRoot` is the component where the modal will actually be rendered.(Mostly it would be at the root of your app)
 
-Modal and ModalRoot must originate from useModal with the same id.
+Modal and `ModalRoot` must be originated from `useJuicyModal` with the same `rootId`.
 
-Then from the modal anywhere in the component, it will be rendered in the ModalRoot.
+Then the modal from any component in the app, it will be rendered in the `ModalRoot`.
 
 ```typescript
-import useJuicyModal from '@juicy-plus/react-juicy-modal'
+import { useJuicyModal } from '@juicy-plus/react-juicy-modal'
 
 const App = () => {
   const { ModalRoot } = useJuicyModal({ rootId: 'modal-root' })
@@ -59,7 +59,7 @@ You can use `JuicyModal`, `openModal`, `closeModal`, etc. in the part where moda
 There must be a `ModalRoot` with matching rootId in the app.
 
 ```typescript
-import useJuicyModal from '@juicy-plus/react-juicy-modal'
+import { useJuicyModal } from '@juicy-plus/react-juicy-modal'
 
 const About = () => {
   const { JuicyModal, closeModal, openModal } = useJuicyModal({
@@ -94,7 +94,7 @@ const About = () => {
 
 ### 4. Example
 
-You can run example by the command below, or just look at the source codes in the directory `exmaple`,
+You can run example by the command below, or just look at the source codes in the directory `exmaple`.
 
 ```bash
 yarn
@@ -103,7 +103,7 @@ yarn example
 
 ### 5. Storybook
 
-try the command below to start storybook
+Try the command below to start storybook.
 
 ```bash
 yarn storybook

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ _Features:_
 
 🌟 Fruity Fresh Design: Say farewell to dull, generic modal designs. React Juicy Modal brings you a wide array of visually captivating modal styles inspired by the vibrant world of fruits. From zesty oranges to luscious grapes, each modal variant breathes life into your user interactions.
 
-## Getting Started🚀
+## 🚀 Getting Started
 
-### Install
+### 1. Install
 
 You can install package by the conmand below
 
@@ -29,7 +29,7 @@ npm install @juicy-plus/react-juicy-modal
 
 you can also use other package managers such as yarn, pnpm
 
-### 1. Use ModalRoot at the root.
+### 2. Use ModalRoot at the root.
 
 Use the component `ModalRoot` where the modal will actually be rendered.(Mostly would be at the root of your app)
 
@@ -52,7 +52,7 @@ const App = () => {
 }
 ```
 
-### 2. Use JuicyModal to decalre modal.
+### 3. Use JuicyModal to decalre modal.
 
 You can use `JuicyModal`, `openModal`, `closeModal`, etc. in the part where modal content is declared.
 
@@ -92,7 +92,7 @@ const About = () => {
 }
 ```
 
-### Example
+### 4. Example
 
 You can run example by the command below, or just look at the source codes in the directory `exmaple`,
 
@@ -101,7 +101,7 @@ yarn
 yarn example
 ```
 
-### run storybook
+### 5. Storybook
 
 try the command below to start storybook
 
@@ -111,13 +111,9 @@ yarn storybook
 
 ## Reporting Bugs and Contributing Code
 
----
-
 - Want to report a bug or request a feature? Please open [an issue](https://github.com/JuicyPlus/react-juicy-modal/issues/new).
 - Want to help us build it? Fork the project, edit in a dev environment and make a pull request. We need your help!
 
 ## License
-
----
 
 The source code for the site is licensed under the MIT license, which you can find in the [MIT-LICENSE.txt file](https://github.com/JuicyPlus/react-juicy-modal/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -29,11 +29,9 @@ npm install @juicy-plus/react-juicy-modal
 
 you can also use other package managers such as yarn, pnpm
 
-### ModalRoot
+### 1. Use ModalRoot at the root.
 
-Use the component `ModalRoot` where the modal will actually be rendered.
-
-For example, at the bottom of the `App.tsx`.
+Use the component `ModalRoot` where the modal will actually be rendered.(Mostly would be at the root of your app)
 
 Modal and ModalRoot must originate from useModal with the same id.
 
@@ -54,7 +52,7 @@ const App = () => {
 }
 ```
 
-### 2. JuicyModal
+### 2. Use JuicyModal to decalre modal.
 
 You can use `JuicyModal`, `openModal`, `closeModal`, etc. in the part where modal content is declared.
 

--- a/README.md
+++ b/README.md
@@ -6,27 +6,104 @@
 
 Introducing React-Juicy-Modal: Ushering in a new era of modal interactions in React applications with fresh, fruity designs 🍊🍇🍓
 
-Demonstration:
+_Demonstration:_
 
 <div align="center">
   <img src="demo.gif" width="450px" height="244px" alt="demonstration of react-juicy-modal"/>
 </div>
 <br/><br/>
 
-Features:
+_Features:_
 
 🌟 Fruity Fresh Design: Say farewell to dull, generic modal designs. React Juicy Modal brings you a wide array of visually captivating modal styles inspired by the vibrant world of fruits. From zesty oranges to luscious grapes, each modal variant breathes life into your user interactions.
 
-### Getting Started
+## Getting Started🚀
 
----
+### Install
 
-This project is not published yet but you can try by cloning this repository in local
+You can install package by the conmand below
+
+```bash
+npm install @juicy-plus/react-juicy-modal
+```
+
+you can also use other package managers such as yarn, pnpm
+
+### ModalRoot
+
+Use the component `ModalRoot` where the modal will actually be rendered.
+
+For example, at the bottom of the `App.tsx`.
+
+Modal and ModalRoot must originate from useModal with the same id.
+
+Then from the modal anywhere in the component, it will be rendered in the ModalRoot.
+
+```typescript
+import useJuicyModal from '@juicy-plus/react-juicy-modal'
+
+const App = () => {
+  const { ModalRoot } = useJuicyModal({ rootId: 'modal-root' })
+
+  return (
+    <div>
+      ...
+      <ModalRoot />
+    </div>
+  )
+}
+```
+
+### 2. JuicyModal
+
+You can use `JuicyModal`, `openModal`, `closeModal`, etc. in the part where modal content is declared.
+
+There must be a `ModalRoot` with matching rootId in the app.
+
+```typescript
+import useJuicyModal from '@juicy-plus/react-juicy-modal'
+
+const About = () => {
+  const { JuicyModal, closeModal, openModal } = useJuicyModal({
+    rootId: 'modal-root'
+  })
+
+  return (
+    <div className="About">
+      <div>About</div>
+      <button onClick={openModal}>Open Modal</button>
+      <JuicyModal
+        title="Title"
+        content="Modal from About"
+        buttons={[
+          {
+            label: 'Confirm',
+            onClick: () => {
+              closeModal()
+              alert('confirm')
+            }
+          },
+          {
+            label: 'Close',
+            onClick: closeModal
+          }
+        ]}
+      />
+    </div>
+  )
+}
+```
+
+### Example
+
+You can run example by the command below, or just look at the source codes in the directory `exmaple`,
 
 ```bash
 yarn
-yarn start
+yarn example
 ```
+
+### run storybook
 
 try the command below to start storybook
 
@@ -34,14 +111,14 @@ try the command below to start storybook
 yarn storybook
 ```
 
-### Reporting Bugs and Contributing Code
+## Reporting Bugs and Contributing Code
 
 ---
 
 - Want to report a bug or request a feature? Please open [an issue](https://github.com/JuicyPlus/react-juicy-modal/issues/new).
 - Want to help us build it? Fork the project, edit in a dev environment and make a pull request. We need your help!
 
-### License
+## License
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "example": "react-scripts start",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint": "eslint \"{src,test}/**/*.{ts,tsx}\" --quiet --fix -c \".eslintrc.json\"",


### PR DESCRIPTION
Updated starting guide how to install and write code with `useModal`

preview:
[readem.md(feature/add-quick-start)](https://github.com/JuicyPlus/react-juicy-modal/tree/feature/add-quick-start)