### PR TITLE
feat: apply new design and theme

### DIFF
--- a/src/lib/components/Button/button.css
+++ b/src/lib/components/Button/button.css
@@ -1,20 +1,12 @@
 .storybook-button {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-weight: 700;
+  font-weight: 600;
   border: 0;
-  border-radius: 3em;
+  border-radius: 15px;
   cursor: pointer;
   display: inline-block;
   line-height: 1;
-}
-.storybook-button--primary {
-  color: white;
-  background-color: #1ea7fd;
-}
-.storybook-button--secondary {
-  color: #333;
-  background-color: transparent;
-  box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
+  box-shadow: 0px 0.5px 1px rgba(0, 0, 0, 0.15) ;
 }
 .storybook-button--small {
   font-size: 12px;

--- a/src/lib/components/Button/index.tsx
+++ b/src/lib/components/Button/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import './button.css'
+import themes from '../../themes'
 
 interface ButtonProps {
   /**
@@ -7,13 +8,25 @@ interface ButtonProps {
    */
   primary?: boolean
   /**
+   * What primary color to use
+   */
+  primaryColor?: string
+  /**
    * What background color to use
    */
   backgroundColor?: string
   /**
+   * What text color to use
+   */
+  textColor?: string
+  /**
    * How large should the button be?
    */
   size?: 'small' | 'medium' | 'large'
+  /**
+   * width of the button
+   */
+  width?: number | string
   /**
    * Button contents
    */
@@ -30,23 +43,31 @@ interface ButtonProps {
 export const Button: React.FC<ButtonProps> = ({
   primary = false,
   size = 'medium',
-  backgroundColor,
+  primaryColor = themes.kiwi.primary,
+  backgroundColor = themes.kiwi.grey,
+  textColor,
   label,
   ...props
 }: ButtonProps) => {
   const mode = primary
     ? 'storybook-button--primary'
-    : 'storybook-button--secondary'
+    : 'storybook-button--normal'
   return (
     <button
       type="button"
       className={['storybook-button', `storybook-button--${size}`, mode].join(
         ' '
       )}
-      style={{ backgroundColor }}
+      style={{
+        flex: 1,
+        backgroundColor: primary ? primaryColor : themes.kiwi.white,
+        color: primary ? themes.kiwi.white : primaryColor
+      }}
       {...props}
     >
       {label}
     </button>
   )
 }
+
+export default Button

--- a/src/lib/components/Modal/index.tsx
+++ b/src/lib/components/Modal/index.tsx
@@ -1,4 +1,6 @@
-import React from 'react'
+import React, { type CSSProperties } from 'react'
+import themes, { type ThemeName } from '../../themes'
+import Button from '../Button'
 
 export interface ButtonData {
   label: string
@@ -10,63 +12,113 @@ export interface ModalProps {
   title?: string
   content?: string
   onClose?: () => void
+  theme?: ThemeName
 }
 
-const Modal: React.FC<ModalProps> = ({ buttons, title, content, onClose }) => {
+const Modal: React.FC<ModalProps> = ({
+  buttons,
+  title,
+  content,
+  onClose,
+  theme = 'kiwi'
+}) => {
+  const { light, primary, grey, white } = themes?.[theme]
+
+  const backgroundColor = light
+
+  const styles: Record<string, CSSProperties> = {
+    box: {
+      position: 'absolute',
+      width: 400,
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)'
+    },
+    modal: {
+      display: 'flex',
+      flex: 1,
+      width: 400,
+      height: '100%',
+      backgroundColor,
+      borderRadius: 30,
+      padding: 24
+    },
+    header: {
+      marginBottom: 14
+    },
+    title: {
+      alignSelf: 'stretch',
+      color: primary,
+      fontFamily: 'Inter',
+      fontSize: 18,
+      fontStyle: 'normal',
+      fontWeight: '600',
+      lineHeight: '28px /* 155.556% */'
+    },
+    body: {
+      alignSelf: 'stretch',
+      color: grey,
+      fontFamily: 'Inter',
+      fontSize: 14,
+      fontStyle: 'normal',
+      fontWeight: '400',
+      lineHeight: '20px /* 142.857% */'
+    },
+    contentBox: {
+      position: 'relative',
+      width: '100%',
+      height: '100%',
+      flex: 1,
+      textAlign: 'left'
+    },
+    footerBox: {
+      display: 'flex',
+      flex: 1,
+      paddingTop: 14
+    },
+    closeIcon: {
+      position: 'absolute',
+      top: -9,
+      right: 0,
+      cursor: 'pointer',
+      color: primary,
+      fontSize: '18pt'
+    },
+    button: {
+      cursor: 'pointer',
+      flexGrow: 1,
+      flexShrink: 0,
+      textAlign: 'center'
+    }
+  }
+
   return (
-    <div
-      style={{
-        // center of the screen
-        position: 'absolute',
-        padding: '20px',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-        backgroundColor: 'rgba(255,255,255,0.8)'
-      }}
-      className="modal"
-    >
-      <div className="modal-content">
-        <div className="modal-header">
-          <div
-            style={{
-              position: 'absolute',
-              top: '0',
-              right: '0',
-              padding: '10px',
-              cursor: 'pointer'
-            }}
-            className="close"
-            onClick={onClose}
-          >
+    <div style={styles.box} className="box">
+      <div style={styles.modal} className="modal">
+        <div className="modal-content" style={styles.contentBox}>
+          <div style={styles.closeIcon} className="close" onClick={onClose}>
             &times;
           </div>
-          <h2>{title}</h2>
-        </div>
-        <div
-          style={{
-            padding: '10px',
-            height: '50px',
-            overflowY: 'auto'
-          }}
-          className="modal-body"
-        >
-          {content}
-        </div>
-        <div className="modal-footer">
-          {buttons?.map(({ label, onClick }) => (
-            <button
-              style={{
-                padding: '10px',
-                margin: '10px',
-                cursor: 'pointer'
-              }}
-              key={label}
-              onClick={onClick}
-            >
-              {label}
-            </button>
-          ))}
+          <div style={styles.header} className="modal-header">
+            <div style={styles.title}>{title}</div>
+          </div>
+          <div style={styles.body} className="modal-body">
+            {content}
+          </div>
+          <div className="modal-footer" style={styles.footerBox}>
+            {buttons?.map(({ label, onClick }, index) => (
+              <div
+                style={{
+                  // marginLeft: index === 0 ? 0 : 10,
+                  ...styles.button
+                }}
+                key={label}
+                onClick={onClick}
+              >
+                <Button label={label} onClick={onClick} />
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/lib/themes/index.ts
+++ b/src/lib/themes/index.ts
@@ -1,4 +1,18 @@
-const theme = {
+export type ThemeName = keyof typeof themes
+
+export interface Theme {
+  primary: string
+  secondary: string
+  grey: string
+  light: string
+  dark: string
+  white: string
+}
+
+// ThemesType is type which has string key and value is type 'Theme'
+type ThemesType = Record<string, Theme>
+
+const themes: ThemesType = {
   orange: {
     primary: '#F0B153',
     secondary: '#5CAD6E',
@@ -25,4 +39,4 @@ const theme = {
   }
 }
 
-export default theme
+export default themes

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,28 @@
+const theme = {
+  orange: {
+    primary: '#F0B153',
+    secondary: '#5CAD6E',
+    grey: '#475467',
+    light: '#F5F5F5',
+    dark: '#9E692A',
+    white: '#FFFFFF'
+  },
+  kiwi: {
+    primary: '#219E0D',
+    secondary: '#776F51',
+    grey: '#475467',
+    light: '#F9FFF2',
+    dark: '#195F0E',
+    white: '#FFFFFF'
+  },
+  grape: {
+    primary: '#5936BD',
+    secondary: '#FF4BC2',
+    grey: '#475467',
+    light: '#F2F8EB',
+    dark: '#493F65',
+    white: '#FFFFFF'
+  }
+}
+
+export default theme


### PR DESCRIPTION
There are some issues left, but I suggest merge this PR and configure those issue later.

Colors are maintained as pallate in `themes.ts`. Theme can be selected by passing the prop the name of theme into the prop `theme` of `JuicyModal`

## screenshots

<img width="450" alt="image" src="https://github.com/JuicyPlus/react-juicy-modal/assets/19814210/8d2164f7-6a39-402e-98ed-e41db911a11d">

<img width="647" alt="image" src="https://github.com/JuicyPlus/react-juicy-modal/assets/19814210/56df16ab-d334-4451-a453-23fcd0569f1f">

<img width="865" alt="image" src="https://github.com/JuicyPlus/react-juicy-modal/assets/19814210/5329c947-790a-4000-9caa-28276811e54c">

### Issues

1.  Issue from design: button should be stretched

2. There is an error form example file as below: 
```
Parsing error: ESLint was configured to run on `<tsconfigRootDir>/src/example/About/index.tsx` using `parserOptions.project`: tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-fileeslint
```